### PR TITLE
Use shell-maker-async-shell-command's preprocess-response

### DIFF
--- a/claude-shell.el
+++ b/claude-shell.el
@@ -5,10 +5,10 @@
 ;; Author: Armin Friedl <dev@friedl.net>
 ;; Maintainer: Armin Friedl <dev@friedl.net>
 ;; Created: März 16, 2024
-;; Version: 0.0.6
+;; Version: 0.0.7
 ;; Keywords: anthropic claude claude-shell shell-maker terminals wp help tools
 ;; Homepage: https://github.com/arminfriedl/claude-shell
-;; Package-Requires: ((emacs "29.1") (shell-maker "0.50.5"))
+;; Package-Requires: ((emacs "29.1") (shell-maker "0.72.1"))
 ;;
 ;; This file is not part of GNU Emacs.
 

--- a/claude-shell.el
+++ b/claude-shell.el
@@ -299,18 +299,6 @@ interpretation."
                (format "Error: %s" .error.message)))
            ""))))
 
-(defun claude-shell--preprocess-claude-response (response)
-  "Preprocess RESPONSE to remove unparseable items."
-  (replace-regexp-in-string
-   (rx (| (: bol "data:")
-          (: bol (| "event: message_start"
-                    "event: content_block_start"
-                    "event: content_block_stop"
-                    "event: message_delta"
-                    "event: message_stop"
-                    "event: ping"
-                    "event: content_block_delta") (*? anychar) eol)))"" response))
-
 (defvar claude-shell--config
   (make-shell-maker-config
    :name "Claude"
@@ -346,6 +334,18 @@ or
                                    "SK-REDACTED-ANTHROPIC-KEY"
                                    output)
        output))))
+
+(defun claude-shell--preprocess-claude-response (response)
+  "Preprocess RESPONSE to remove unparseable items."
+  (replace-regexp-in-string
+   (rx (| (: bol "data:")
+          (: bol (| "event: message_start"
+                    "event: content_block_start"
+                    "event: content_block_stop"
+                    "event: message_delta"
+                    "event: message_stop"
+                    "event: ping"
+                    "event: content_block_delta") (*? anychar) eol)))"" response))
 
 ;;;###autoload
 (defun claude-shell ()


### PR DESCRIPTION
Advice is no longer needed. Preprocessing now done by clients. Will soon remove the tiny logic in shell-maker to clear "data:" from response.